### PR TITLE
Bump Log4j2 to 2.23.1

### DIFF
--- a/data/conf/hive-log4j2.properties
+++ b/data/conf/hive-log4j2.properties
@@ -16,7 +16,6 @@
 
 status = INFO
 name = HiveLog4j2Test
-packages = org.apache.hadoop.hive.ql.log
 
 # list of properties
 property.hive.log.level = DEBUG
@@ -24,9 +23,6 @@ property.hive.root.logger = DRFA
 property.hive.log.dir = ${sys:test.tmp.dir}/log
 property.hive.log.file = hive.log
 property.hive.test.console.log.level = INFO
-
-# list of all appenders
-appenders = console, DRFA
 
 # console appender
 appender.console.type = Console
@@ -48,9 +44,6 @@ appender.DRFA.policies.time.interval = 1
 appender.DRFA.policies.time.modulate = true
 appender.DRFA.strategy.type = DefaultRolloverStrategy
 appender.DRFA.strategy.max = 30
-
-# list of all loggers
-loggers = HadoopIPC, HadoopSecurity, Hdfs, HdfsServer, HadoopMetrics2, Mortbay, Yarn, YarnServer, Tez, HadoopConf, Zookeeper, ServerCnxn, NIOServerCnxn, ClientCnxn, ClientCnxnSocket, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX, Operator, Serde2Lazy, ObjectStore, CalcitePlanner, AmazonAws, ApacheHttp, Thrift, Jetty, BlockStateChange, swo, CBORuleLogger
 
 logger.HadoopIPC.name = org.apache.hadoop.ipc
 logger.HadoopIPC.level = WARN
@@ -128,7 +121,7 @@ logger.CBORuleLogger.filter.marker.type = MarkerFilter
 logger.CBORuleLogger.filter.marker.marker = FULL_PLAN
 # Change filter to ACCEPT, to see the produced plan after every rule invocation using the EXPLAIN CBO format
 logger.CBORuleLogger.filter.marker.onMatch = DENY
-logger.CBORuleLogger.filter.marker.onMisMatch = NEUTRAL
+logger.CBORuleLogger.filter.marker.onMismatch = NEUTRAL
 
 logger.AmazonAws.name=com.amazonaws
 logger.AmazonAws.level = INFO

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -367,9 +367,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
+      <artifactId>log4j-core-test</artifactId>
       <version>${log4j2.version}</version>
-      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/QueryTracker.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/QueryTracker.java
@@ -48,8 +48,9 @@ import org.apache.tez.common.security.JobTokenIdentifier;
 import org.apache.tez.common.security.TokenCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.Marker;
 import org.slf4j.MDC;
+import org.slf4j.Marker;
+import org.slf4j.impl.StaticMarkerBinder;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -70,7 +71,7 @@ public class QueryTracker extends AbstractService {
 
   private static final Logger LOG = LoggerFactory.getLogger(QueryTracker.class);
   private static final Marker QUERY_COMPLETE_MARKER =
-      new Log4jMarker(new Log4jQueryCompleteMarker());
+      new Log4jMarker(StaticMarkerBinder.getSingleton().getMarkerFactory(), new Log4jQueryCompleteMarker());
 
   /// Shared singleton MetricsSource instance for all DAG locks
   private static final MetricsSource LOCK_METRICS;

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TestLlapDaemonLogging.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TestLlapDaemonLogging.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hive.testutils.junit.extensions.DoNothingTCPServer;
 import org.apache.hive.testutils.junit.extensions.DoNothingTCPServerExtension;
-import org.apache.logging.log4j.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
 import org.apache.tez.common.security.TokenCache;
 
 import org.junit.jupiter.api.Test;

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
     <!-- Leaving libfb303 at 0.9.3 regardless of libthrift: As per THRIFT-4613 The Apache Thrift project does not publish items related to fb303 at this point -->
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.18.0</log4j2.version>
+    <log4j2.version>2.23.0</log4j2.version>
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.31</mysql.version>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
     <!-- Leaving libfb303 at 0.9.3 regardless of libthrift: As per THRIFT-4613 The Apache Thrift project does not publish items related to fb303 at this point -->
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.23.0</log4j2.version>
+    <log4j2.version>2.23.1</log4j2.version>
     <mariadb.version>2.5.0</mariadb.version>
     <mssql.version>6.2.1.jre8</mssql.version>
     <mysql.version>8.0.31</mysql.version>

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -412,9 +412,13 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
+      <artifactId>log4j-core-test</artifactId>
       <version>${log4j2.version}</version>
-      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/utils/TestMetaStoreServerUtils.java
@@ -44,7 +44,7 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.apache.thrift.TException;
 import org.hamcrest.core.IsNot;
 import org.junit.After;

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -89,7 +89,7 @@
     <junit.vintage.version>5.6.3</junit.vintage.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.23.0</log4j2.version>
+    <log4j2.version>2.23.1</log4j2.version>
     <mockito-core.version>3.4.4</mockito-core.version>
     <orc.version>1.8.5</orc.version>
     <protobuf.version>3.24.4</protobuf.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -89,7 +89,7 @@
     <junit.vintage.version>5.6.3</junit.vintage.version>
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.16.0</libthrift.version>
-    <log4j2.version>2.18.0</log4j2.version>
+    <log4j2.version>2.23.0</log4j2.version>
     <mockito-core.version>3.4.4</mockito-core.version>
     <orc.version>1.8.5</orc.version>
     <protobuf.version>3.24.4</protobuf.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

- For https://github.com/apache/hive/pull/5375 .


### Why are the changes needed?

### Does this PR introduce _any_ user-facing change?

### Is the change a dependency upgrade?

### How was this patch tested?

```shell
git clone git@github.com:linghengqian/hive.git -b test-v2230-log4j
cd ./hive/
sdk install java 8.0.422-tem
sdk use java 8.0.422-tem
sdk install maven
mvn clean install -DskipTests
mvn test -Dtest=TestHplsqlLocal
```

- Log as follow. See `/hive/hplsql/target/surefire-reports`.

```shell
-------------------------------------------------------------------------------
Test set: org.apache.hive.hplsql.TestHplsqlLocal
-------------------------------------------------------------------------------
Tests run: 86, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.909 s <<< FAILURE! - in org.apache.hive.hplsql.TestHplsqlLocal
org.apache.hive.hplsql.TestHplsqlLocal.testException  Time elapsed: 0.63 s  <<< FAILURE!
org.junit.ComparisonFailure: 
expected:<[]Ln:2 PRINT
Correct
L...> but was:<[2024-08-02T15:19:31.463Z main DEBUG Using ShutdownCallbackRegistry class org.apache.logging.log4j.core.util.DefaultShutdownCallbackRegistry
2024-08-02T15:19:31.465Z main TRACE Log4jLoggerFactory.getContext() found anchor class org.apache.hive.hplsql.Exec
2024-08-02T15:19:31.527Z main DEBUG Took 0.055332 seconds to load 265 plugins from sun.misc.Launcher$AppClassLoader@3d4eac69
2024-08-02T15:19:31.527Z main DEBUG PluginManager 'Lookup' found 17 plugins
2024-08-02T15:19:31.541Z main DEBUG PluginManager 'Lookup' found 17 plugins
2024-08-02T15:19:31.544Z main DEBUG PluginManager 'Converter' found 48 plugins
2024-08-02T15:19:31.557Z main DEBUG Starting OutputStreamManager SYSTEM_OUT.false.false-1
2024-08-02T15:19:31.558Z main DEBUG Starting LoggerContext[name=3d4eac69, org.apache.logging.log4j.core.LoggerContext@5a7fe64f]...
2024-08-02T15:19:31.558Z main DEBUG Reconfiguration started for context[name=3d4eac69] at URI null (org.apache.logging.log4j.core.LoggerContext@5a7fe64f) with optional ClassLoader: null
2024-08-02T15:19:31.559Z main DEBUG PluginManager 'Lookup' found 17 plugins
2024-08-02T15:19:31.560Z main DEBUG PluginManager 'ConfigurationFactory' found 6 plugins
2024-08-02T15:19:31.561Z main DEBUG PluginManager 'Lookup' found 17 plugins
2024-08-02T15:19:31.562Z main DEBUG PluginManager 'Lookup' found 17 plugins
2024-08-02T15:19:31.605Z main DEBUG PluginManager 'Lookup' found 17 plugins
2024-08-02T15:19:31.605Z main DEBUG PluginManager 'Lookup' found 17 plugins
2024-08-02T15:19:31.605Z main DEBUG PluginManager 'Lookup' found 17 plugins
2024-08-02T15:19:31.605Z main DEBUG PluginManager 'Lookup' found 17 plugins
2024-08-02T15:19:31.606Z main DEBUG Using configurationFactory org.apache.logging.log4j.core.config.ConfigurationFactory$Factory@4b5189ac
2024-08-02T15:19:31.614Z main DEBUG PluginManager 'Lookup' found 17 plugins
2024-08-02T15:19:31.616Z main DEBUG Apache Log4j Core 2.23 initializing configuration org.apache.logging.log4j.core.config.properties.PropertiesConfiguration@31920ade
2024-08-02T15:19:31.617Z main DEBUG PluginManager 'Core' found 140 plugins
2024-08-02T15:19:31.617Z main DEBUG PluginManager 'Level' found 0 plugins
2024-08-02T15:19:31.619Z main DEBUG Building Plugin[name=property, class=org.apache.logging.log4j.core.config.Property].
2024-08-02T15:19:31.624Z main TRACE TypeConverterRegistry initializing.
2024-08-02T15:19:31.624Z main DEBUG PluginManager 'TypeConverter' found 26 plugins
2024-08-02T15:19:31.628Z main DEBUG createProperty(name="hive.log.file", value="hive.log", Configuration(HiveLog4j2Test))
2024-08-02T15:19:31.628Z main DEBUG Building Plugin[name=property, class=org.apache.logging.log4j.core.config.Property].
2024-08-02T15:19:31.628Z main DEBUG createProperty(name="hive.log.dir", value="${sys:test.tmp.dir}/log", Configuration(HiveLog4j2Test))
2024-08-02T15:19:31.629Z main DEBUG Building Plugin[name=property, class=org.apache.logging.log4j.core.config.Property].
2024-08-02T15:19:31.629Z main DEBUG createProperty(name="hive.root.logger", value="DRFA", Configuration(HiveLog4j2Test))
2024-08-02T15:19:31.629Z main DEBUG Building Plugin[name=property, class=org.apache.logging.log4j.core.config.Property].
2024-08-02T15:19:31.629Z main DEBUG createProperty(name="hive.log.level", value="DEBUG", Configuration(HiveLog4j2Test))
2024-08-02T15:19:31.629Z main DEBUG Building Plugin[name=property, class=org.apache.logging.log4j.core.config.Property].
2024-08-02T15:19:31.629Z main DEBUG createProperty(name="hive.test.console.log.level", value="INFO", Configuration(HiveLog4j2Test))
2024-08-02T15:19:31.630Z main DEBUG Building Plugin[name=properties, class=org.apache.logging.log4j.core.config.PropertiesPlugin].
2024-08-02T15:19:31.631Z main DEBUG configureSubstitutor(={hive.log.file=hive.log, hive.log.dir=/home/linghengqian/TwinklingLiftWorks/git/public/hive/hplsql/target/tmp/log, hive.root.logger=DRFA, hive.log.level=DEBUG, hive.test.console.log.level=INFO}, Configuration(HiveLog4j2Test))
2024-08-02T15:19:31.632Z main DEBUG PluginManager 'Lookup' found 17 plugins
2024-08-02T15:19:31.632Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.636Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="org.apache.hadoop.hive.ql.exec.Operator", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.637Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.637Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="com.amazonaws", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.637Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.637Z main DEBUG LoggerConfig$Builder(additivity="null", level="WARN", levelAndRefs="null", name="BlockStateChange", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.637Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.638Z main DEBUG LoggerConfig$Builder(additivity="null", level="WARN", levelAndRefs="null", name="org.apache.zookeeper.server.NIOServerCnxn", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.638Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.638Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="org.apache.tez", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.638Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.639Z main DEBUG LoggerConfig$Builder(additivity="null", level="DEBUG", levelAndRefs="null", name="org.apache.hadoop.hive.ql.optimizer.SharedWorkOptimizer", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.639Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.639Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="org.apache.hadoop.hdfs", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.639Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.639Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="org.apache.http", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.639Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.639Z main DEBUG LoggerConfig$Builder(additivity="null", level="ERROR", levelAndRefs="null", name="JPOX", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.639Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.640Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="org.apache.hadoop.yarn", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.640Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.640Z main DEBUG LoggerConfig$Builder(additivity="null", level="WARN", levelAndRefs="null", name="org.apache.zookeeper.server.ServerCnxn", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.640Z main DEBUG Building Plugin[name=filter, class=org.apache.logging.log4j.core.filter.MarkerFilter].
2024-08-02T15:19:31.641Z main DEBUG createFilter(marker="FULL_PLAN", onMatch="DENY", onMismatch="NEUTRAL")
2024-08-02T15:19:31.641Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.642Z main DEBUG LoggerConfig$Builder(additivity="null", level="OFF", levelAndRefs="null", name="org.apache.hadoop.hive.ql.optimizer.calcite.RuleEventLogger", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), MarkerFilter(FULL_PLAN))
2024-08-02T15:19:31.642Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.642Z main DEBUG LoggerConfig$Builder(additivity="null", level="WARN", levelAndRefs="null", name="org.apache.hadoop.yarn.server", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.642Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.642Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="org.apache.calcite.plan.RelOptPlanner", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.642Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.643Z main DEBUG LoggerConfig$Builder(additivity="null", level="WARN", levelAndRefs="null", name="org.apache.zookeeper.ClientCnxnSocket", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.643Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.643Z main DEBUG LoggerConfig$Builder(additivity="null", level="ERROR", levelAndRefs="null", name="org.apache.hadoop.conf.Configuration", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.643Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.644Z main DEBUG LoggerConfig$Builder(additivity="null", level="WARN", levelAndRefs="null", name="org.apache.thrift", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.644Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.644Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="org.apache.hadoop.hive.metastore.ObjectStore", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.644Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.644Z main DEBUG LoggerConfig$Builder(additivity="null", level="WARN", levelAndRefs="null", name="org.apache.hadoop.hdfs.server", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.644Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.644Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="org.apache.hadoop.metrics2", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.644Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.645Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="org.apache.hadoop.hive.serde2.lazy", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.645Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.645Z main DEBUG LoggerConfig$Builder(additivity="null", level="WARN", levelAndRefs="null", name="org.apache.zookeeper.ClientCnxn", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.645Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.645Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="org.apache.hadoop.security", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.645Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.645Z main DEBUG LoggerConfig$Builder(additivity="null", level="WARN", levelAndRefs="null", name="org.apache.hadoop.ipc", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.645Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.645Z main DEBUG LoggerConfig$Builder(additivity="null", level="WARN", levelAndRefs="null", name="org.apache.zookeeper.ClientCnxnSocketNIO", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.646Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.646Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="org.mortbay", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.646Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.646Z main DEBUG LoggerConfig$Builder(additivity="null", level="ERROR", levelAndRefs="null", name="DataNucleus", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.646Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.646Z main DEBUG LoggerConfig$Builder(additivity="null", level="ERROR", levelAndRefs="null", name="Datastore", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.646Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.647Z main DEBUG LoggerConfig$Builder(additivity="null", level="INFO", levelAndRefs="null", name="org.apache.zookeeper", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.647Z main DEBUG Building Plugin[name=logger, class=org.apache.logging.log4j.core.config.LoggerConfig].
2024-08-02T15:19:31.647Z main DEBUG LoggerConfig$Builder(additivity="null", level="WARN", levelAndRefs="null", name="org.eclipse.jetty", includeLocation="null", ={}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.647Z main DEBUG Building Plugin[name=AppenderRef, class=org.apache.logging.log4j.core.config.AppenderRef].
2024-08-02T15:19:31.648Z main DEBUG createAppenderRef(ref="console", level="INFO", Filter=null)
2024-08-02T15:19:31.648Z main DEBUG Building Plugin[name=AppenderRef, class=org.apache.logging.log4j.core.config.AppenderRef].
2024-08-02T15:19:31.648Z main DEBUG createAppenderRef(ref="DRFA", level="null", Filter=null)
2024-08-02T15:19:31.648Z main DEBUG Building Plugin[name=root, class=org.apache.logging.log4j.core.config.LoggerConfig$RootLogger].
2024-08-02T15:19:31.649Z main DEBUG LoggerConfig$RootLogger$Builder(additivity="null", level="DEBUG", levelAndRefs="null", includeLocation="null", ={console, DRFA}, ={}, Configuration(HiveLog4j2Test), Filter=null)
2024-08-02T15:19:31.649Z main DEBUG Building Plugin[name=loggers, class=org.apache.logging.log4j.core.config.LoggersPlugin].
2024-08-02T15:19:31.649Z main DEBUG createLoggers(={org.apache.hadoop.hive.ql.exec.Operator, com.amazonaws, BlockStateChange, org.apache.zookeeper.server.NIOServerCnxn, org.apache.tez, org.apache.hadoop.hive.ql.optimizer.SharedWorkOptimizer, org.apache.hadoop.hdfs, org.apache.http, JPOX, org.apache.hadoop.yarn, org.apache.zookeeper.server.ServerCnxn, org.apache.hadoop.hive.ql.optimizer.calcite.RuleEventLogger, org.apache.hadoop.yarn.server, org.apache.calcite.plan.RelOptPlanner, org.apache.zookeeper.ClientCnxnSocket, org.apache.hadoop.conf.Configuration, org.apache.thrift, org.apache.hadoop.hive.metastore.ObjectStore, org.apache.hadoop.hdfs.server, org.apache.hadoop.metrics2, org.apache.hadoop.hive.serde2.lazy, org.apache.zookeeper.ClientCnxn, org.apache.hadoop.security, org.apache.hadoop.ipc, org.apache.zookeeper.ClientCnxnSocketNIO, org.mortbay, DataNucleus, Datastore, org.apache.zookeeper, org.eclipse.jetty, root})
2024-08-02T15:19:31.649Z main DEBUG Building Plugin[name=layout, class=org.apache.logging.log4j.core.layout.PatternLayout].
2024-08-02T15:19:31.650Z main DEBUG PatternLayout$Builder(pattern="%d{ISO8601} %5p [%t] %c{2}: %m%n", PatternSelector=null, Configuration(HiveLog4j2Test), Replace=null, charset="null", alwaysWriteExceptions="null", disableAnsi="null", noConsoleNoAnsi="null", header="null", footer="null")
2024-08-02T15:19:31.650Z main DEBUG PluginManager 'Converter' found 48 plugins
2024-08-02T15:19:31.657Z main DEBUG Building Plugin[name=appender, class=org.apache.logging.log4j.core.appender.ConsoleAppender].
2024-08-02T15:19:31.659Z main DEBUG ConsoleAppender$Builder(target="SYSTEM_ERR", follow="null", direct="null", bufferedIo="null", bufferSize="null", immediateFlush="null", ignoreExceptions="null", PatternLayout(%d{ISO8601} %5p [%t] %c{2}: %m%n), name="console", Configuration(HiveLog4j2Test), Filter=null, ={})
2024-08-02T15:19:31.661Z main DEBUG Starting OutputStreamManager SYSTEM_ERR.false.false
2024-08-02T15:19:31.661Z main DEBUG Building Plugin[name=layout, class=org.apache.logging.log4j.core.layout.PatternLayout].
2024-08-02T15:19:31.662Z main DEBUG PatternLayout$Builder(pattern="%d{ISO8601} %5p [%t] %c{2}: %m%n", PatternSelector=null, Configuration(HiveLog4j2Test), Replace=null, charset="null", alwaysWriteExceptions="null", disableAnsi="null", noConsoleNoAnsi="null", header="null", footer="null")
2024-08-02T15:19:31.663Z main DEBUG Building Plugin[name=TimeBasedTriggeringPolicy, class=org.apache.logging.log4j.core.appender.rolling.TimeBasedTriggeringPolicy].
2024-08-02T15:19:31.664Z main DEBUG TimeBasedTriggeringPolicy$Builder(interval="1", modulate="true", maxRandomDelay="null")
2024-08-02T15:19:31.664Z main DEBUG Building Plugin[name=Policies, class=org.apache.logging.log4j.core.appender.rolling.CompositeTriggeringPolicy].
2024-08-02T15:19:31.665Z main DEBUG createPolicy(={TimeBasedTriggeringPolicy(nextRolloverMillis=0, interval=1, modulate=true)})
2024-08-02T15:19:31.665Z main DEBUG Building Plugin[name=DefaultRolloverStrategy, class=org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy].
2024-08-02T15:19:31.666Z main DEBUG DefaultRolloverStrategy$Builder(max="30", min="null", fileIndex="null", compressionLevel="null", ={}, stopCustomActionsOnError="null", tempCompressedFilePattern="null", Configuration(HiveLog4j2Test))
2024-08-02T15:19:31.666Z main DEBUG Building Plugin[name=appender, class=org.apache.logging.log4j.core.appender.RollingRandomAccessFileAppender].
2024-08-02T15:19:31.667Z main DEBUG RollingRandomAccessFileAppender$Builder(fileName="/home/linghengqian/TwinklingLiftWorks/git/public/hive/hplsql/target/tmp/log/hive.log", filePattern="/home/linghengqian/TwinklingLiftWorks/git/public/hive/hplsql/target/tmp/log/hive.log.%d{yyyy-MM-dd}", append="null", Policies(CompositeTriggeringPolicy(policies=[TimeBasedTriggeringPolicy(nextRolloverMillis=0, interval=1, modulate=true)])), DefaultRolloverStrategy(DefaultRolloverStrategy(min=1, max=30, useMax=true)), advertise="null", advertiseURI="null", filePermissions="null", fileOwner="null", fileGroup="null", bufferedIo="null", bufferSize="null", immediateFlush="null", ignoreExceptions="null", PatternLayout(%d{ISO8601} %5p [%t] %c{2}: %m%n), name="DRFA", Configuration(HiveLog4j2Test), Filter=null, ={})
2024-08-02T15:19:31.670Z main TRACE RandomAccessFile /home/linghengqian/TwinklingLiftWorks/git/public/hive/hplsql/target/tmp/log/hive.log seek to 0
2024-08-02T15:19:31.671Z main DEBUG Starting RollingRandomAccessFileManager /home/linghengqian/TwinklingLiftWorks/git/public/hive/hplsql/target/tmp/log/hive.log
2024-08-02T15:19:31.671Z main DEBUG PluginManager 'FileConverter' found 3 plugins
2024-08-02T15:19:31.675Z main DEBUG Setting prev file time to 2024-08-02T08:19:31.669-0700
2024-08-02T15:19:31.675Z main DEBUG Initializing triggering policy CompositeTriggeringPolicy(policies=[TimeBasedTriggeringPolicy(nextRolloverMillis=0, interval=1, modulate=true)])
2024-08-02T15:19:31.675Z main DEBUG Initializing triggering policy TimeBasedTriggeringPolicy(nextRolloverMillis=0, interval=1, modulate=true)
2024-08-02T15:19:31.676Z main TRACE PatternProcessor.getNextTime returning 2024/08/03-00:00:00.000, nextFileTime=2024/08/02-00:00:00.000, prevFileTime=1969/12/31-16:00:00.000, current=2024/08/02-08:19:31.676, freq=DAILY
2024-08-02T15:19:31.677Z main TRACE PatternProcessor.getNextTime returning 2024/08/03-00:00:00.000, nextFileTime=2024/08/02-00:00:00.000, prevFileTime=2024/08/02-00:00:00.000, current=2024/08/02-08:19:31.676, freq=DAILY
2024-08-02T15:19:31.677Z main DEBUG Building Plugin[name=appenders, class=org.apache.logging.log4j.core.config.AppendersPlugin].
2024-08-02T15:19:31.677Z main DEBUG createAppenders(={console, DRFA})
2024-08-02T15:19:31.677Z main DEBUG Configuration org.apache.logging.log4j.core.config.properties.PropertiesConfiguration@31920ade initialized
2024-08-02T15:19:31.677Z main DEBUG Starting configuration org.apache.logging.log4j.core.config.properties.PropertiesConfiguration@31920ade
2024-08-02T15:19:31.678Z main DEBUG Started configuration org.apache.logging.log4j.core.config.properties.PropertiesConfiguration@31920ade OK.
2024-08-02T15:19:31.678Z main TRACE Stopping org.apache.logging.log4j.core.config.DefaultConfiguration@4201c465...
2024-08-02T15:19:31.678Z main TRACE DefaultConfiguration notified 1 ReliabilityStrategies that config will be stopped.
2024-08-02T15:19:31.678Z main TRACE DefaultConfiguration stopping root LoggerConfig.
2024-08-02T15:19:31.678Z main TRACE DefaultConfiguration notifying ReliabilityStrategies that appenders will be stopped.
2024-08-02T15:19:31.678Z main TRACE DefaultConfiguration stopping remaining Appenders.
2024-08-02T15:19:31.678Z main DEBUG Shutting down OutputStreamManager SYSTEM_OUT.false.false-1
2024-08-02T15:19:31.678Z main DEBUG OutputStream closed
2024-08-02T15:19:31.678Z main DEBUG Shut down OutputStreamManager SYSTEM_OUT.false.false-1, all resources released: true
2024-08-02T15:19:31.678Z main DEBUG Appender DefaultConsole-1 stopped with status true
2024-08-02T15:19:31.678Z main TRACE DefaultConfiguration stopped 1 remaining Appenders.
2024-08-02T15:19:31.678Z main TRACE DefaultConfiguration cleaning Appenders from 1 LoggerConfigs.
2024-08-02T15:19:31.678Z main DEBUG Stopped org.apache.logging.log4j.core.config.DefaultConfiguration@4201c465 OK
2024-08-02T15:19:31.710Z main TRACE Reregistering MBeans after reconfigure. Selector=org.apache.logging.log4j.core.selector.ClassLoaderContextSelector@d62fe5b
2024-08-02T15:19:31.710Z main TRACE Reregistering context (1/1): '3d4eac69' org.apache.logging.log4j.core.LoggerContext@5a7fe64f
2024-08-02T15:19:31.710Z main TRACE Unregistering but no MBeans found matching 'org.apache.logging.log4j2:type=3d4eac69'
2024-08-02T15:19:31.710Z main TRACE Unregistering but no MBeans found matching 'org.apache.logging.log4j2:type=3d4eac69,component=StatusLogger'
2024-08-02T15:19:31.710Z main TRACE Unregistering but no MBeans found matching 'org.apache.logging.log4j2:type=3d4eac69,component=ContextSelector'
2024-08-02T15:19:31.710Z main TRACE Unregistering but no MBeans found matching 'org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=*'
2024-08-02T15:19:31.711Z main TRACE Unregistering but no MBeans found matching 'org.apache.logging.log4j2:type=3d4eac69,component=Appenders,name=*'
2024-08-02T15:19:31.711Z main TRACE Unregistering but no MBeans found matching 'org.apache.logging.log4j2:type=3d4eac69,component=AsyncAppenders,name=*'
2024-08-02T15:19:31.711Z main TRACE Unregistering but no MBeans found matching 'org.apache.logging.log4j2:type=3d4eac69,component=AsyncLoggerRingBuffer'
2024-08-02T15:19:31.711Z main TRACE Unregistering but no MBeans found matching 'org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=*,subtype=RingBuffer'
2024-08-02T15:19:31.712Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69
2024-08-02T15:19:31.713Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=StatusLogger
2024-08-02T15:19:31.714Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=ContextSelector
2024-08-02T15:19:31.714Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=
2024-08-02T15:19:31.715Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.tez
2024-08-02T15:19:31.715Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=com.amazonaws
2024-08-02T15:19:31.715Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.thrift
2024-08-02T15:19:31.715Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=BlockStateChange
2024-08-02T15:19:31.715Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.eclipse.jetty
2024-08-02T15:19:31.715Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.metrics2
2024-08-02T15:19:31.715Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.zookeeper.ClientCnxn
2024-08-02T15:19:31.715Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.zookeeper
2024-08-02T15:19:31.715Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=JPOX
2024-08-02T15:19:31.715Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.security
2024-08-02T15:19:31.715Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.hive.ql.optimizer.SharedWorkOptimizer
2024-08-02T15:19:31.716Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.yarn.server
2024-08-02T15:19:31.716Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.conf.Configuration
2024-08-02T15:19:31.716Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.yarn
2024-08-02T15:19:31.716Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.zookeeper.ClientCnxnSocketNIO
2024-08-02T15:19:31.716Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.zookeeper.server.ServerCnxn
2024-08-02T15:19:31.716Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.hdfs
2024-08-02T15:19:31.716Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.hdfs.server
2024-08-02T15:19:31.716Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.hive.serde2.lazy
2024-08-02T15:19:31.716Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.zookeeper.ClientCnxnSocket
2024-08-02T15:19:31.716Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.mortbay
2024-08-02T15:19:31.717Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.hive.ql.optimizer.calcite.RuleEventLogger
2024-08-02T15:19:31.717Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.http
2024-08-02T15:19:31.717Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.hive.ql.exec.Operator
2024-08-02T15:19:31.717Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=DataNucleus
2024-08-02T15:19:31.718Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.hive.metastore.ObjectStore
2024-08-02T15:19:31.718Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=Datastore
2024-08-02T15:19:31.718Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.hadoop.ipc
2024-08-02T15:19:31.718Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.zookeeper.server.NIOServerCnxn
2024-08-02T15:19:31.718Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Loggers,name=org.apache.calcite.plan.RelOptPlanner
2024-08-02T15:19:31.719Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Appenders,name=console
2024-08-02T15:19:31.719Z main DEBUG Registering MBean org.apache.logging.log4j2:type=3d4eac69,component=Appenders,name=DRFA
2024-08-02T15:19:31.720Z main TRACE Using default SystemClock for timestamps.
2024-08-02T15:19:31.720Z main DEBUG org.apache.logging.log4j.core.util.SystemClock does not support precise timestamps.
2024-08-02T15:19:31.720Z main TRACE Using DummyNanoClock for nanosecond timestamps.
2024-08-02T15:19:31.720Z main DEBUG Reconfiguration complete for context[name=3d4eac69] at URI /home/linghengqian/TwinklingLiftWorks/git/public/hive/hplsql/target/testconf/hive-log4j2.properties (org.apache.logging.log4j.core.LoggerContext@5a7fe64f) with optional ClassLoader: null
2024-08-02T15:19:31.721Z main DEBUG Shutdown hook enabled. Registering a new one.
2024-08-02T15:19:31.721Z main DEBUG LoggerContext[name=3d4eac69, org.apache.logging.log4j.core.LoggerContext@5a7fe64f] started OK.
2024-08-02T15:19:31.752Z main TRACE Log4jLoggerFactory.getContext() found anchor class org.apache.hadoop.conf.Configuration
2024-08-02T15:19:31.752Z main TRACE Log4jLoggerFactory.getContext() found anchor class org.apache.hadoop.conf.Configuration
2024-08-02T15:19:31.758Z main TRACE Log4jLoggerFactory.getContext() found anchor class org.apache.hadoop.util.Preconditions
]Ln:2 PRINT
Correct
L...>
	at org.junit.Assert.assertEquals(Assert.java:117)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.apache.hive.hplsql.TestHplsqlLocal.run(TestHplsqlLocal.java:482)
	at org.apache.hive.hplsql.TestHplsqlLocal.testException(TestHplsqlLocal.java:229)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:43)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:183)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.Iterator.forEachRemaining(Iterator.java:116)
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1801)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485)
	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:82)
	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:73)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:248)
	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$5(DefaultLauncher.java:211)
	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:226)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:199)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:132)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:154)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:123)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:377)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:138)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:465)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:451)
```
